### PR TITLE
fixed assetVersionId-to-assetId url

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Asset APIs
     
 #####Get the assetId of an assetVersionId:
 ```bat
-curl http://www.roblox.com/redirect-item?avid=1 --head
+curl http://www.roblox.com/_-item?avid=1 --head
 ```
 
 #####Download the latest version of an asset


### PR DESCRIPTION
The previous URL will fail if the asset is named "redirect". The URL of an asset named "_" becomes "unnamed", so using "_" as the URL will redirect as expected.
