### PR TITLE
Add a catalog search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Search APIs
 -----------
 http://www.roblox.com/games/list-json?sortFilter=1&MaxRows=5
 
+####Search for an audio asset with the search term "pendulum fasten"
 http://www.roblox.com/catalog/json?Category=9&Keyword=pendulum%20fasten
 
 Place APIs


### PR DESCRIPTION
Minor addition demonstrating how to search the catalog for an audio  asset.
