### PR TITLE
Add setup.roblox.com/DeployHistory.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Setup APIs
   *	[/version(.txt)](http://setup.roblox.com/version)
   *	[/versionStudio(.txt)](http://setup.roblox.com/versionStudio)
   *	[/versionQTStudio](http://setup.roblox.com/versionQTStudio)
-  * [DeployHistory.txt](http://setup.roblox.com/mac/DeployHistory.txt)
+  * [/DeployHistory.txt](http://setup.roblox.com/mac/DeployHistory.txt)
   *	[/mac/version](http://setup.roblox.com/mac/version)
   *	[/mac/versionStudio](http://setup.roblox.com/mac/versionStudio)
   *	[/mac/RobloxStudio.dmg](http://setup.roblox.com/mac/RobloxStudio.dmg)

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Setup APIs
   *	[/version(.txt)](http://setup.roblox.com/version)
   *	[/versionStudio(.txt)](http://setup.roblox.com/versionStudio)
   *	[/versionQTStudio](http://setup.roblox.com/versionQTStudio)
+  * [DeployHistory.txt](http://setup.roblox.com/mac/DeployHistory.txt)
   *	[/mac/version](http://setup.roblox.com/mac/version)
   *	[/mac/versionStudio](http://setup.roblox.com/mac/versionStudio)
   *	[/mac/RobloxStudio.dmg](http://setup.roblox.com/mac/RobloxStudio.dmg)
+  * [/mac/DeployHistory.txt](http://setup.roblox.com/mac/DeployHistory.txt)


### PR DESCRIPTION
DeployHistory is an endpoint that just logs any time the roblox client or studio changes. It dates back to 2009

please note that .txt is required