### PR TITLE
Removing /mac from /DeployHistory.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Setup APIs
   *	[/version(.txt)](http://setup.roblox.com/version)
   *	[/versionStudio(.txt)](http://setup.roblox.com/versionStudio)
   *	[/versionQTStudio](http://setup.roblox.com/versionQTStudio)
-  * [/DeployHistory.txt](http://setup.roblox.com/mac/DeployHistory.txt)
+  * [/DeployHistory.txt](http://setup.roblox.com/DeployHistory.txt)
   *	[/mac/version](http://setup.roblox.com/mac/version)
   *	[/mac/versionStudio](http://setup.roblox.com/mac/versionStudio)
   *	[/mac/RobloxStudio.dmg](http://setup.roblox.com/mac/RobloxStudio.dmg)


### PR DESCRIPTION
Removes the /mac from DeployHistory.txt as there is a seperate reference for mac/deployhistory.txt further down